### PR TITLE
Integrate Rack CORS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,8 @@ gem 'bcrypt', '~> 3.1.7'
 # gem 'capistrano-rails', group: :development
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
+gem 'rack-cors', require: 'rack/cors'
+
 group :production do
   gem 'pg'
   gem 'rails_12factor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       method_source (~> 0.9.0)
     puma (3.12.0)
     rack (2.0.6)
+    rack-cors (1.0.2)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.1.6.1)
@@ -144,6 +145,7 @@ DEPENDENCIES
   pg
   pry
   puma (~> 3.7)
+  rack-cors
   rails (~> 5.1.6)
   rails_12factor
   spring
@@ -152,4 +154,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,12 @@ module EFurnitureApi
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
     config.autoload_paths << Rails.root.join('lib')
+
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins '*'
+        resource '*', headers: :any, methods: [:get, :post, :options]
+      end
+    end
   end
 end


### PR DESCRIPTION
* Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible